### PR TITLE
Make REPL work again

### DIFF
--- a/java-src/io/pulse/parquet/TupleEntrySupport.java
+++ b/java-src/io/pulse/parquet/TupleEntrySupport.java
@@ -1,5 +1,6 @@
 package io.pulse.parquet;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import cascading.tuple.TupleEntry;
 import org.apache.hadoop.conf.Configuration;
@@ -62,9 +63,15 @@ public class TupleEntrySupport extends WriteSupport<TupleEntry> {
       case INT64:
         rc.addLong(record.getLong(tupleField));
         break;
-      case BINARY:
-        rc.addBinary(Binary.fromByteArray(record.getString(tupleField).getBytes("UTF-8")));
-        break;
+      case BINARY: {
+        try {
+          rc.addBinary(Binary.fromByteArray(record.getString(tupleField).getBytes("UTF-8")));
+          break;
+        } catch (UnsupportedEncodingException e) {
+          // Ignore. Doesn't compile otherwise.
+          break;
+        }
+      }
       default:
         break;
       }

--- a/project.clj
+++ b/project.clj
@@ -15,5 +15,5 @@
   :repositories [["conjars" "https://conjars.org/repo"]]
   :profiles {:dev {:dependencies [[org.apache.hadoop/hadoop-core "1.1.2"]
                                   [javax.jdo/jdo2-api "2.3-eb"]
-                                  [org.apache.hive/hive-metastore "0.10.0"
+                                  [org.apache.hive/hive-metastore "0.12.0"
                                    :exclusions [javax.jdo/jdo2-api]]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/pulseio/parquet-cascalog/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [cascalog "2.0.0"]
                  [com.twitter/parquet-column "1.2.4"]
                  [com.twitter/parquet-hadoop "1.2.4"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
   :aliases {"build" ["do" "compile," "javac"]}
   :java-source-paths ["java-src"]
   :aot [parquet-cascalog.convert]
-  :repositories [["conjars" "http://conjars.org/repo"]]
+  :repositories [["conjars" "https://conjars.org/repo"]]
   :profiles {:dev {:dependencies [[org.apache.hadoop/hadoop-core "1.1.2"]
                                   [javax.jdo/jdo2-api "2.3-eb"]
                                   [org.apache.hive/hive-metastore "0.10.0"


### PR DESCRIPTION
This is a quick solution to make the REPL work with recent Leiningen and Java versions. The nREPL did not work for the unmodified version.

These changes update the Clojure version, one dependency that is so old that it forces Leiningen do download via HTTP (which ne Leiningens do not allow) and catch some exceptions in order to make a method compilable in recent Java versions.